### PR TITLE
Install instead of searching on Arch

### DIFF
--- a/_setup/001-install.md
+++ b/_setup/001-install.md
@@ -20,7 +20,7 @@ For Linux
 
 ### For Arch Linux
 
-    sudo pacman -Ss postgresql
+    sudo pacman -S postgresql
 
 ### For YUM installations (Fedora / Red Hat / CentOS / Scientific Linux)
 


### PR DESCRIPTION
The previously shown command for installation on Arch Linux would only search the package repository. Instead, show the command to directly install it, as it is for Ubuntu.
